### PR TITLE
Normalization fix to rely on head words, not phrases.

### DIFF
--- a/evaluate.py
+++ b/evaluate.py
@@ -46,7 +46,7 @@ def normalize_object_phrase_list(phrase_list: List[str]) -> List[str]:
         if head_word in seen:
             continue
         seen.add(head_word)
-        normalized_phrase_list.append(phrase)
+        normalized_phrase_list.append(head_word)
     return normalized_phrase_list
 
 


### PR DESCRIPTION
Hi!

It looks like there is an error in the provided 'normalize_object_phrase_list' function.
Resulting list is getting constructed not from head words, but from original phrases.

Kind regards,
Tsimafei